### PR TITLE
Adding support for plugin PDB configs

### DIFF
--- a/version/Core/Private/Helpers.cpp
+++ b/version/Core/Private/Helpers.cpp
@@ -1,0 +1,62 @@
+#include "Helpers.h"
+#include <algorithm>
+#include <cctype>
+
+namespace ArkApi
+{
+	void MergePdbConfig(nlohmann::json &left, nlohmann::json right)
+	{
+		left["structures"] = MergeStringArrays(left.value("structures", std::vector<std::string> {}),
+			right.value("structures", std::vector<std::string> {}));
+		left["functions"] = MergeStringArrays(left.value("functions", std::vector<std::string> {}),
+			right.value("functions", std::vector<std::string> {}));
+	}
+
+	std::vector<std::string> MergeStringArrays(std::vector<std::string> first, std::vector<std::string> second)
+	{
+		std::vector<std::string> merged, unique;
+		std::sort(first.begin(), first.end());
+		std::sort(second.begin(), second.end());
+		std::set_union(
+			first.begin(), 
+			first.end(),
+			second.begin(), 
+			second.end(),
+			std::back_inserter(merged),
+			[] (std::string s1, std::string s2)
+			{
+				return std::lexicographical_compare(
+					s1.begin(), 
+					s1.end(), 
+					s2.begin(), 
+					s2.end(),
+					[] (char c1, char c2)
+					{
+						return std::tolower(c1) < std::tolower(c2);
+					}
+				);
+			}
+		);
+
+		std::unique_copy(
+			merged.begin(), 
+			merged.end(), 
+			std::back_inserter(unique),
+			[] (std::string s1, std::string s2)
+			{
+				return std::equal(
+					s1.begin(), 
+					s1.end(), 
+					s2.begin(), 
+					s2.end(),
+					[] (char c1, char c2)
+					{
+						return std::tolower(c1) == std::tolower(c2);
+					}
+				);
+			}
+		);
+
+		return unique;
+	}
+}

--- a/version/Core/Private/Helpers.h
+++ b/version/Core/Private/Helpers.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <vector>
+#include "../../json.hpp"
+
+namespace ArkApi
+{
+	void MergePdbConfig(nlohmann::json &left, nlohmann::json right);
+	std::vector<std::string> MergeStringArrays(std::vector<std::string> first, std::vector<std::string> second);
+}

--- a/version/Core/Private/PDBReader/PDBReader.cpp
+++ b/version/Core/Private/PDBReader/PDBReader.cpp
@@ -7,10 +7,11 @@
 #include <Tools.h>
 
 #include "../Private/Offsets.h"
+#include "../Private/Helpers.h"
 
 namespace ArkApi
 {
-	void PdbReader::Read(std::wstring path, std::unordered_map<std::string, intptr_t>* offsets_dump,
+	void PdbReader::Read(std::wstring path, nlohmann::json plugin_pdb_config, std::unordered_map<std::string, intptr_t>* offsets_dump,
 	                     std::unordered_map<std::string, BitField>* bitfields_dump)
 	{
 		offsets_dump_ = offsets_dump;
@@ -36,6 +37,17 @@ namespace ArkApi
 
 		if (!ReadConfig())
 			throw std::runtime_error("Failed to open config.json");
+
+		try
+		{
+			MergePdbConfig(config_, plugin_pdb_config);
+		}
+		catch (const std::runtime_error&)
+		{
+			Log::GetLog()->error("Failed to merge api config with pdb configs");
+			throw;
+		}
+
 
 		Log::GetLog()->info("Dumping structures..");
 		DumpStructs(symbol);

--- a/version/Core/Private/PDBReader/PDBReader.h
+++ b/version/Core/Private/PDBReader/PDBReader.h
@@ -16,7 +16,7 @@ namespace ArkApi
 		{
 		}
 
-		void Read(std::wstring path, std::unordered_map<std::string, intptr_t>* offsets_dump,
+		void Read(std::wstring path, nlohmann::json plugin_pdb_config, std::unordered_map<std::string, intptr_t>* offsets_dump,
 		          std::unordered_map<std::string, BitField>* bitfields_dump);
 
 	private:

--- a/version/Core/Private/PluginManager/PluginManager.h
+++ b/version/Core/Private/PluginManager/PluginManager.h
@@ -45,6 +45,11 @@ namespace ArkApi
 		PluginManager& operator=(PluginManager&&) = delete;
 
 		/**
+		* \brief Get all plugin pdb configs
+		*/
+		static nlohmann::json PluginManager::GetAllPDBConfigs();
+
+		/**
 		 * \brief Find and load all plugins
 		 */
 		void LoadAllPlugins();
@@ -79,6 +84,7 @@ namespace ArkApi
 		~PluginManager() = default;
 
 		static nlohmann::json ReadPluginInfo(const std::string& plugin_name);
+		static nlohmann::json ReadPluginPDBConfig(const std::string& plugin_name);
 
 		void CheckPluginsDependencies();
 

--- a/version/version.cpp
+++ b/version/version.cpp
@@ -51,10 +51,21 @@ void Init()
 	std::unordered_map<std::string, intptr_t> offsets_dump;
 	std::unordered_map<std::string, BitField> bitfields_dump;
 
+	nlohmann::json plugin_pdb_config;
+	try
+	{
+		plugin_pdb_config = PluginManager::GetAllPDBConfigs();
+	}
+	catch (const std::exception& error)
+	{
+		Log::GetLog()->critical("Failed to read plugin pdb configs - {}", error.what());
+		return;
+	}
+
 	try
 	{
 		const std::wstring dir = Tools::ConvertToWideStr(current_dir);
-		pdb_reader.Read(dir + L"/ShooterGameServer.pdb", &offsets_dump, &bitfields_dump);
+		pdb_reader.Read(dir + L"/ShooterGameServer.pdb", plugin_pdb_config, &offsets_dump, &bitfields_dump);
 	}
 	catch (const std::exception& error)
 	{

--- a/version/version.vcxproj
+++ b/version/version.vcxproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ClInclude Include="Core\Private\ApiUtils.h" />
     <ClInclude Include="Core\Private\Commands.h" />
+    <ClInclude Include="Core\Private\Helpers.h" />
     <ClInclude Include="Core\Private\Hooks.h" />
     <ClInclude Include="Core\Private\HooksImpl.h" />
     <ClInclude Include="Core\Private\Offsets.h" />
@@ -111,6 +112,7 @@
     <ClCompile Include="Core\Private\ApiUtils.cpp" />
     <ClCompile Include="Core\Private\Base.cpp" />
     <ClCompile Include="Core\Private\Commands.cpp" />
+    <ClCompile Include="Core\Private\Helpers.cpp" />
     <ClCompile Include="Core\Private\Hooks.cpp" />
     <ClCompile Include="Core\Private\HooksImpl.cpp" />
     <ClCompile Include="Core\Private\Logger.cpp" />

--- a/version/version.vcxproj.filters
+++ b/version/version.vcxproj.filters
@@ -339,6 +339,9 @@
     <ClInclude Include="Core\Public\Logger\Logger.h">
       <Filter>Core\Public\Logger</Filter>
     </ClInclude>
+    <ClInclude Include="Core\Private\Helpers.h">
+      <Filter>Core\Private</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="version.cpp" />
@@ -370,6 +373,9 @@
       <Filter>Core\Private</Filter>
     </ClCompile>
     <ClCompile Include="Core\Private\Logger.cpp">
+      <Filter>Core\Private</Filter>
+    </ClCompile>
+    <ClCompile Include="Core\Private\Helpers.cpp">
       <Filter>Core\Private</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
This feature let plugin authors include a `PdbConfig.json` file in deployments that get merged into the main API `Config.json` when parsing PDB structures and global functions.

This makes plugin installations that require additional structures much easier for the end user.