### PR TITLE
Added server status

### DIFF
--- a/version/Core/Private/ApiUtils.cpp
+++ b/version/Core/Private/ApiUtils.cpp
@@ -32,6 +32,18 @@ namespace ArkApi
 		return shooter_game_mode_;
 	}
 
+	// Status
+
+	void ApiUtils::SetStatus(ServerStatus status)
+	{
+		status_ = status;
+	}
+
+	ServerStatus ApiUtils::GetStatus() const
+	{
+		return status_;
+	}
+
 	// Free function
 	IApiUtils& GetApiUtils()
 	{

--- a/version/Core/Private/ApiUtils.h
+++ b/version/Core/Private/ApiUtils.h
@@ -16,9 +16,11 @@ namespace ArkApi
 
 		UWorld* GetWorld() const override;
 		AShooterGameMode* GetShooterGameMode() const override;
+		ServerStatus GetStatus() const override;
 
 		void SetWorld(UWorld* uworld);
 		void SetShooterGameMode(AShooterGameMode* shooter_game_mode);
+		void SetStatus(ServerStatus status);
 
 	private:
 		ApiUtils()
@@ -31,5 +33,6 @@ namespace ArkApi
 
 		UWorld* u_world_;
 		AShooterGameMode* shooter_game_mode_;
+		ServerStatus status_;
 	};
 }

--- a/version/Core/Private/HooksImpl.cpp
+++ b/version/Core/Private/HooksImpl.cpp
@@ -19,6 +19,7 @@ namespace ArkApi
 	DECLARE_HOOK(APlayerController_ConsoleCommand, FString*, APlayerController*, FString*, FString*, bool);
 	DECLARE_HOOK(RCONClientConnection_ProcessRCONPacket, void, RCONClientConnection*, RCONPacket*, UWorld*);
 	DECLARE_HOOK(AGameState_DefaultTimer, void, AGameState*);
+	DECLARE_HOOK(AShooterGameMode_BeginPlay, void, AShooterGameMode*);
 
 	void InitHooks()
 	{
@@ -36,6 +37,7 @@ namespace ArkApi
 		hooks.SetHook("RCONClientConnection.ProcessRCONPacket", &Hook_RCONClientConnection_ProcessRCONPacket,
 		              &RCONClientConnection_ProcessRCONPacket_original);
 		hooks.SetHook("AGameState.DefaultTimer", &Hook_AGameState_DefaultTimer, &AGameState_DefaultTimer_original);
+		hooks.SetHook("AShooterGameMode.BeginPlay", &Hook_AShooterGameMode_BeginPlay, &AShooterGameMode_BeginPlay_original);
 
 		Log::GetLog()->info("Initialized hooks\n");
 	}
@@ -115,5 +117,12 @@ namespace ArkApi
 		Commands::Get().CheckOnTimerCallbacks();
 
 		AGameState_DefaultTimer_original(_this);
+	}
+
+	void Hook_AShooterGameMode_BeginPlay(AShooterGameMode *_AShooterGameMode)
+	{
+		AShooterGameMode_BeginPlay_original(_AShooterGameMode);
+
+		ApiUtils::Get().SetStatus(ServerStatus::Ready);
 	}
 }

--- a/version/Core/Public/IApiUtils.h
+++ b/version/Core/Public/IApiUtils.h
@@ -5,6 +5,8 @@
 
 namespace ArkApi
 {
+	enum class ServerStatus { Loading, Ready };
+
 	class ARK_API IApiUtils
 	{
 	public:
@@ -19,6 +21,11 @@ namespace ArkApi
 		* \brief Returns a pointer to AShooterGameMode
 		*/
 		virtual AShooterGameMode* GetShooterGameMode() const = 0;
+
+		/**
+		* \brief Returns the current server status
+		*/
+		virtual ServerStatus GetStatus() const = 0;
 
 		/**
 		* \brief Sends server message to the specific player. Using fmt::format.


### PR DESCRIPTION
To support load/unload of plugins that require code to run at a certain point during startup.

Example
```cpp
void Load()
{
   if (ArkApi::GetApiUtils().GetStatus() == ArkApi::ServerStatus::Ready)
      Init();
   else
      ArkApi::GetHooks().SetHook(
         "AShooterGameMode.BeginPlay", 
         &Hook_AShooterGameMode_BeginPlay, 
         &AShooterGameMode_BeginPlay_original);
}

void Hook_AShooterGameMode_BeginPlay(AShooterGameMode *_AShooterGameMode)
{
   AShooterGameMode_BeginPlay_original(_AShooterGameMode);
   Init();
}

void Init()
{
   // initialization code here ...
}
```