### PR TITLE
Support for PDB global variables

### DIFF
--- a/config.json
+++ b/config.json
@@ -76,11 +76,15 @@
 	"UShooterGameInstance",
 	"AMatineeActor",
 	"UEngine",
+	"UPrimalGlobals"
 	"FSocket"
   ],
   "functions": [
     "StaticLoadObject",
     "RaycastSingle",
 	"StaticConstructObject"
+  ],
+  "globals": [
+  	"GEngine"
   ]
 }

--- a/version/Core/Private/Base.cpp
+++ b/version/Core/Private/Base.cpp
@@ -12,6 +12,11 @@ LPVOID GetAddress(const std::string& name)
 	return ArkApi::Offsets::Get().GetAddress(name);
 }
 
+LPVOID GetDataAddress(const std::string& name)
+{
+	return ArkApi::Offsets::Get().GetDataAddress(name);
+}
+
 BitField GetBitField(const void* base, const std::string& name)
 {
 	return ArkApi::Offsets::Get().GetBitField(base, name);

--- a/version/Core/Private/Helpers.cpp
+++ b/version/Core/Private/Helpers.cpp
@@ -10,6 +10,8 @@ namespace ArkApi
 		                                       right.value("structures", std::vector<std::string>{}));
 		left["functions"] = MergeStringArrays(left.value("functions", std::vector<std::string>{}),
 		                                      right.value("functions", std::vector<std::string>{}));
+		left["globals"] = MergeStringArrays(left.value("globals", std::vector<std::string>{}),
+		                                    right.value("globals", std::vector<std::string>{}));
 	}
 
 	std::vector<std::string> MergeStringArrays(std::vector<std::string> first, std::vector<std::string> second)

--- a/version/Core/Private/Offsets.h
+++ b/version/Core/Private/Offsets.h
@@ -20,6 +20,8 @@ namespace ArkApi
 		DWORD64 GetAddress(const void* base, const std::string& name);
 		LPVOID GetAddress(const std::string& name);
 
+		LPVOID GetDataAddress(const std::string& name);
+
 		BitField GetBitField(const void* base, const std::string& name);
 		BitField GetBitField(LPVOID base, const std::string& name);
 
@@ -30,6 +32,7 @@ namespace ArkApi
 		BitField GetBitFieldInternal(const void* base, const std::string& name);
 
 		DWORD64 module_base_;
+		DWORD64 data_base_;
 		std::unordered_map<std::string, intptr_t> offsets_dump_;
 		std::unordered_map<std::string, BitField> bitfields_dump_;
 	};

--- a/version/Core/Private/PDBReader/PDBReader.h
+++ b/version/Core/Private/PDBReader/PDBReader.h
@@ -24,6 +24,7 @@ namespace ArkApi
 		bool ReadConfig();
 		void DumpStructs(IDiaSymbol*);
 		void DumpFreeFunctions(IDiaSymbol*);
+		void DumpGlobalVariables(IDiaSymbol*);
 		void DumpType(IDiaSymbol*, const std::string&, int) const;
 		void DumpData(IDiaSymbol*, const std::string&) const;
 		static std::string GetName(IDiaSymbol*);

--- a/version/Core/Public/API/ARK/GameMode.h
+++ b/version/Core/Public/API/ARK/GameMode.h
@@ -174,6 +174,18 @@ struct UWorld : UObject
 	static void StaticRegisterNativesUWorld() { NativeCall<void>(nullptr, "UWorld.StaticRegisterNativesUWorld"); }
 };
 
+struct UEngine : UObject
+{
+	FieldValue<UPrimalGlobals *> GameSingletonField() { return { this, "UEngine.GameSingleton" }; } // UObject *
+};
+
+struct UPrimalGlobals : UObject
+{
+	FieldValue<UPrimalGameData *> PrimalGameDataField() { return { this, "UPrimalGlobals.PrimalGameData" }; }
+	FieldValue<UPrimalGameData *> PrimalGameDataOverrideField() { return { this, "UPrimalGlobals.PrimalGameDataOverride" }; }
+};
+
+
 // Level
 
 struct ULevelBase

--- a/version/Core/Public/API/Base.h
+++ b/version/Core/Public/API/Base.h
@@ -144,6 +144,9 @@ struct UCharacterMovementComponent{};
 struct FDinoExtraDefaultItemList{};
 struct FWeaponData{};
 struct FAIRequestID{};
+struct UPrimalGameData;
+struct UEngine;
+struct UPrimalGlobals;
 
 struct BitField
 {
@@ -157,6 +160,8 @@ struct BitField
 
 ARK_API DWORD64 GetAddress(const void* base, const std::string& name);
 ARK_API LPVOID GetAddress(const std::string& name);
+
+ARK_API LPVOID GetDataAddress(const std::string& name);
 
 ARK_API BitField GetBitField(const void* base, const std::string& name);
 ARK_API BitField GetBitField(LPVOID base, const std::string& name);

--- a/version/Core/Public/API/Fields.h
+++ b/version/Core/Public/API/Fields.h
@@ -30,6 +30,12 @@ RT GetNativePointerField(const void* _this, const std::string& field_name)
 	return reinterpret_cast<RT>(GetAddress(_this, field_name));
 }
 
+template <typename RT>
+RT GetNativeDataPointerField(const std::string& field_name)
+{
+	return reinterpret_cast<RT>(GetDataAddress(field_name));
+}
+
 template <typename RT, typename T>
 RT GetNativeBitField(const void* _this, const std::string& field_name)
 {
@@ -126,6 +132,40 @@ public:
 
 private:
 	T* value_;
+};
+
+template <typename T>
+class DataValue
+{
+public:
+	DataValue(const std::string& field_name)
+		: value_(GetNativeDataPointerField<T*>(field_name))
+	{
+	}
+
+	T& operator()() const
+	{
+		return *value_;
+	}
+
+	T& operator=(const T& other)
+	{
+		*value_ = other;
+		return *value_;
+	}
+
+	T& Get() const
+	{
+		return *value_;
+	}
+
+	void Set(const T& other)
+	{
+		*value_ = other;
+	}
+
+private:
+	T * value_;
 };
 
 template <typename RT, typename T>

--- a/version/Core/Public/API/UE/UE.h
+++ b/version/Core/Public/API/UE/UE.h
@@ -493,6 +493,8 @@ struct Globals
 		const auto flags_value = static_cast<std::underlying_type<ClassCastFlags>::type>(flags);
 		return _class != nullptr && (_class->ClassCastFlagsField()() & flags_value) == flags_value;
 	}
+
+	static DataValue<UEngine *> GEngine() { return { "Global.GEngine" }; }
 };
 
 template <>


### PR DESCRIPTION
Adds support for global variables from UE/ARK. Many of them previously inaccessible.

Added GEngine as an example. Fetching it could previously be done through hooks, but since it was not done in the API, supporting unloading/loading in a plugin that depends on it becomes tough.

UEngine and UPrimalGlobals could be updated to support more fields.

What do you think?