### PR TITLE
Adding chat hook callbacks

### DIFF
--- a/version/Core/Private/Commands.cpp
+++ b/version/Core/Private/Commands.cpp
@@ -37,6 +37,11 @@ namespace ArkApi
 		on_timer_callbacks_.push_back(std::make_shared<OnTimerCallback>(id, callback));
 	}
 
+	void Commands::AddOnChatMessageCallback(const FString& id, const std::function<bool(AShooterPlayerController*, FString*, EChatSendMode::Type, bool, bool)>& callback)
+	{
+		on_chat_message_callbacks_.push_back(std::make_shared<OnChatMessageCallback>(id, callback));
+	}
+
 	bool Commands::RemoveChatCommand(const FString& command)
 	{
 		return RemoveCommand<ChatCommand>(command, chat_commands_);
@@ -60,6 +65,11 @@ namespace ArkApi
 	bool Commands::RemoveOnTimerCallback(const FString& id)
 	{
 		return RemoveCommand<OnTimerCallback>(id, on_timer_callbacks_);
+	}
+
+	bool Commands::RemoveOnChatMessageCallback(const FString& id)
+	{
+		return RemoveCommand<OnChatMessageCallback>(id, on_chat_message_callbacks_);
 	}
 
 	bool Commands::CheckChatCommands(AShooterPlayerController* shooter_player_controller, FString* message,
@@ -93,6 +103,22 @@ namespace ArkApi
 		{
 			data->callback();
 		}
+	}
+
+	bool Commands::CheckOnChatMessageCallbacks(
+		AShooterPlayerController* player_controller, 
+		FString* message, 
+		EChatSendMode::Type mode, 
+		bool spam_check, 
+		bool command_executed)
+	{
+		bool prevent_default = false;
+		for (const auto& data : on_chat_message_callbacks_)
+		{
+			prevent_default |= data->callback(player_controller, message, mode, spam_check, command_executed);
+		}
+
+		return prevent_default;
 	}
 
 	// Free function

--- a/version/Core/Private/Commands.h
+++ b/version/Core/Private/Commands.h
@@ -29,6 +29,7 @@ namespace ArkApi
 
 		void AddOnTickCallback(const FString& id, const std::function<void(float)>& callback) override;
 		void AddOnTimerCallback(const FString& id, const std::function<void()>& callback) override;
+		void AddOnChatMessageCallback(const FString& id, const std::function<bool(AShooterPlayerController*, FString*, EChatSendMode::Type, bool, bool)>& callback) override;
 
 		bool RemoveChatCommand(const FString& command) override;
 		bool RemoveConsoleCommand(const FString& command) override;
@@ -36,6 +37,7 @@ namespace ArkApi
 
 		bool RemoveOnTickCallback(const FString& id) override;
 		bool RemoveOnTimerCallback(const FString& id) override;
+		bool RemoveOnChatMessageCallback(const FString& id) override;
 
 		bool CheckChatCommands(AShooterPlayerController* shooter_player_controller, FString* message,
 		                       EChatSendMode::Type mode);
@@ -44,6 +46,7 @@ namespace ArkApi
 		                       UWorld* u_world);
 		void CheckOnTickCallbacks(float delta_seconds);
 		void CheckOnTimerCallbacks();
+		bool CheckOnChatMessageCallbacks(AShooterPlayerController* player_controller, FString* message, EChatSendMode::Type mode, bool spam_check, bool command_executed);
 
 	private:
 		Commands() = default;
@@ -68,6 +71,7 @@ namespace ArkApi
 
 		using OnTickCallback = Command<void(float)>;
 		using OnTimerCallback = Command<void()>;
+		using OnChatMessageCallback = Command<bool(AShooterPlayerController*, FString*, EChatSendMode::Type, bool, bool)>;
 
 		template <typename T>
 		bool RemoveCommand(const FString& command, std::vector<std::shared_ptr<T>>& commands)
@@ -118,5 +122,6 @@ namespace ArkApi
 
 		std::vector<std::shared_ptr<OnTickCallback>> on_tick_callbacks_;
 		std::vector<std::shared_ptr<OnTimerCallback>> on_timer_callbacks_;
+		std::vector<std::shared_ptr<OnChatMessageCallback>> on_chat_message_callbacks_;
 	};
 }

--- a/version/Core/Public/ICommands.h
+++ b/version/Core/Public/ICommands.h
@@ -50,6 +50,13 @@ namespace ArkApi
 		virtual void AddOnTimerCallback(const FString& id, const std::function<void()>& callback) = 0;
 
 		/**
+		* \brief Added function will be called for AShooterPlayerController->ServerSendChatMessage events
+		* \param id Unique ID
+		* \param callback Callback function
+		*/
+		virtual void AddOnChatMessageCallback(const FString& id, const std::function<bool(AShooterPlayerController*, FString*, EChatSendMode::Type, bool, bool)>& callback) = 0;
+
+		/**
 		 * \brief Removes a chat command
 		 * \param command Command name
 		 * \return true if success, false otherwise
@@ -83,6 +90,13 @@ namespace ArkApi
 		 * \return true if success, false otherwise
 		 */
 		virtual bool RemoveOnTimerCallback(const FString& id) = 0;
+
+		/**
+		* \brief Removes an on-chat-message callback
+		* \param id Callback ID
+		* \return true if success, false otherwise
+		*/
+		virtual bool RemoveOnChatMessageCallback(const FString& id) = 0;
 	};
 
 	ARK_API ICommands& APIENTRY GetCommands();


### PR DESCRIPTION
Allows plugins to control the flow and know the actions taken by the API in this hook (_AShooterPlayerController->ServerSendChatMessage).