### PR TITLE
Safer automatic plugin reloading

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,8 @@
 {
   "settings":{
     "AutomaticPluginReloading":false,
-    "AutomaticPluginReloadSeconds":5
+    "AutomaticPluginReloadSeconds":5,
+    "SaveWorldBeforePluginReload":true
   },
   "structures":[
     "UWorld",

--- a/version/Core/Private/PluginManager/PluginManager.h
+++ b/version/Core/Private/PluginManager/PluginManager.h
@@ -89,6 +89,7 @@ namespace ArkApi
 
 		void CheckPluginsDependencies();
 
+		static void DetectPluginChangesTimerCallback();
 		void DetectPluginChanges();
 
 		// Callbacks
@@ -98,6 +99,9 @@ namespace ArkApi
 		std::vector<std::shared_ptr<Plugin>> loaded_plugins_;
 
 		// Plugins auto reloading
+		bool enable_plugin_reload_;
 		int reload_sleep_seconds_;
+		bool save_world_before_reload_;
+		time_t next_reload_check_;
 	};
 }


### PR DESCRIPTION
Plugin check and reload now occurs in the game loop thread (OnTimer callback) to prevent potential race condition crashes such as when a plugin is unloaded while the game is executing code inside the DLL module (there might be a high possibility for these race conditions when plugins hook into the OnTick method which executes around 30 times per second). The changes now detects changes and reloads plugins from the game's main loop (OnTimer callback).

Plugin reloading optionally saves world just before reloading to prevent rollbacks if unloading a plugin that does not support unloading properly, or the new plugin causes crashes. The option is available in config.json in a new variable called
`"SaveWorldBeforePluginReload":true` (if this value does not exist in config.json it is enabled by default).

Additionally the first plugin load on server startup (**PluginManager::LoadAllPlugins**) now also uses the new **.dll.ArkApi** if it exists so that plugin updates can be distributed regardless of the server status.